### PR TITLE
[DM-35845] Fix quoting of Etag header

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,20 @@ name: CI
   pull_request: {}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
   test:
     runs-on: ubuntu-latest
 
@@ -27,30 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
-
-      - name: Install tox
-        run: pip install tox
-
-      - name: Cache tox environments
-        id: cache-tox
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          # requirements/*.txt and pyproject.toml have versioning info
-          # that would impact the tox environment.
-          key: tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
-
-      - name: Run tox
-        run: tox -e py,coverage-report,typing
+          tox-envs: "py,coverage-report,typing"
 
   build:
     runs-on: ubuntu-latest

--- a/src/crawlspace/services/file.py
+++ b/src/crawlspace/services/file.py
@@ -41,7 +41,7 @@ class CrawlspaceFile:
             "Cache-Control": f"private, max-age={config.cache_max_age}",
             "Content-Length": str(blob.size),
             "Last-Modified": format_datetime(blob.updated, usegmt=True),
-            "Etag": blob.etag,
+            "Etag": f'"{blob.etag}"',
         }
         if path.endswith(".fits"):
             media_type = "application/fits"


### PR DESCRIPTION
The etag value returned by the GCS API doesn't include the double
quotes that are required in the Etag header format, which in turn
led browsers to send the same value back, at which point we'd
reject it because the syntax wasn't valid.  Add the double quotes
and test it properly.