### PR TITLE
DM-37516: Update typing to avoid deprecations

### DIFF
--- a/src/crawlspace/config.py
+++ b/src/crawlspace/config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
 
 __all__ = ["Configuration", "config"]
 
@@ -22,7 +21,7 @@ class Configuration:
     environment variable.
     """
 
-    gcs_project: Optional[str] = os.getenv("CRAWLSPACE_PROJECT")
+    gcs_project: str = os.getenv("CRAWLSPACE_PROJECT", "None")
     """The GCS project from which to serve files.
 
     Set with the ``CRAWLSPACE_PROJECT`` environment variable.

--- a/src/crawlspace/dependencies/etag.py
+++ b/src/crawlspace/dependencies/etag.py
@@ -1,7 +1,6 @@
 """Dependency to handle browser cache requests."""
 
 import re
-from typing import List
 
 from fastapi import Depends, Request
 from safir.dependencies.logger import logger_dependency
@@ -15,7 +14,7 @@ __all__ = ["etag_validation_dependency"]
 
 async def etag_validation_dependency(
     request: Request, logger: BoundLogger = Depends(logger_dependency)
-) -> List[str]:
+) -> list[str]:
     """Parse browser cache ETag validation headers.
 
     Browsers with a cached file that has expired will attempt to revalidate it

--- a/src/crawlspace/handlers/external.py
+++ b/src/crawlspace/handlers/external.py
@@ -1,7 +1,6 @@
 """Handlers for the app's external root, ``/crawlspace/``."""
 
 import re
-from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 from fastapi.responses import RedirectResponse
@@ -39,7 +38,7 @@ def get_file(
     request: Request,
     path: str = Path(..., title="File path", regex=PATH_REGEX),
     gcs: storage.Client = Depends(gcs_client_dependency),
-    etags: List[str] = Depends(etag_validation_dependency),
+    etags: list[str] = Depends(etag_validation_dependency),
     logger: BoundLogger = Depends(logger_dependency),
 ) -> Response:
     logger.debug("File request", path=path)

--- a/src/crawlspace/services/file.py
+++ b/src/crawlspace/services/file.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from email.utils import format_datetime
 from mimetypes import guess_type
-from typing import Dict, Iterator
 
 from google.cloud import storage
 
@@ -23,7 +23,7 @@ class CrawlspaceFile:
     media_type: str
     """The media type of the underlying file."""
 
-    headers: Dict[str, str]
+    headers: dict[str, str]
     """Additional response headers to send."""
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
-from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio


### PR DESCRIPTION
Fix the deprecations in PEP 585, and use the | syntax instead of Union and some Optional cases.