### PR TITLE
DM-51236: Get config from a file instead of env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ EXPOSE 8080
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Run the application.
-CMD ["uvicorn", "crawlspace.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "--factory", "crawlspace.main:create_app", "--host", "0.0.0.0", "--port", "8080"]

--- a/changelog.d/20250605_160911_danfuchs_HEAD.md
+++ b/changelog.d/20250605_160911_danfuchs_HEAD.md
@@ -1,0 +1,7 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+- Config needs to come from a YAML file instead of env vars. This will allow us
+  to have more complicated config, like to specify a mapping of different
+  datasets to different GCS buckets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "uvicorn[standard]",
 
     # Other dependencies.
+    "pydantic>=2.11",
     "google-cloud-storage",
     "safir[gcs]",
 ]

--- a/src/crawlspace/config.py
+++ b/src/crawlspace/config.py
@@ -2,67 +2,74 @@
 
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Self
 
-__all__ = ["Configuration", "config"]
+import yaml
+from pydantic import BaseModel, Field
+
+__all__ = ["Config"]
 
 
-@dataclass
-class Configuration:
+class Config(BaseModel):
     """Configuration for crawlspace."""
 
-    cache_max_age: int = int(os.getenv("CRAWLSPACE_CACHE_MAX_AGE", "3600"))
+    cache_max_age: Annotated[
+        int, Field(default=3600, validation_alias="cacheMaxAge")
+    ]
     """Length of time in seconds for which browsers should cache results.
 
     The default is one hour.  Set this shorter for testing when the content
     may be changing frequently, and longer for production when serving static
-    data that rarely varies.  Set with the ``CRAWLSPACE_CACHE_MAX_AGE``
-    environment variable.
+    data that rarely varies.
     """
 
-    gcs_project: str = os.getenv("CRAWLSPACE_PROJECT", "None")
-    """The GCS project from which to serve files.
+    gcs_project: Annotated[
+        str, Field(default="None", validation_alias="gcsProject")
+    ]
+    """The GCS project from which to serve files."""
 
-    Set with the ``CRAWLSPACE_PROJECT`` environment variable.
-    """
+    gcs_bucket: Annotated[
+        str, Field(default="None", validation_alias="gcsBucket")
+    ]
+    """The GCS bucket name from which to serve files."""
 
-    gcs_bucket: str = os.getenv("CRAWLSPACE_BUCKET", "None")
-    """The GCS bucket name from which to serve files.
+    url_prefix: Annotated[
+        str, Field(default="/api/hips", validation_alias="urlPrefix")
+    ]
+    """URL prefix for routes."""
 
-    Set with the ``CRAWLSPACE_BUCKET`` environment variable.
-    """
+    name: Annotated[str, Field(default="crawlspace", validation_alias="name")]
+    """The application's name, which doubles as the root HTTP endpoint path."""
 
-    url_prefix: str = os.getenv("CRAWLSPACE_URL_PREFIX", "/api/hips")
-    """URL prefix for routes.
+    profile: Annotated[
+        str, Field(default="production", validation_alias="profile")
+    ]
+    """Application run profile: "development" or "production"."""
 
-    Set with the ``CRAWLSPACE_URL_PREFIX`` environment variable.
-    """
+    logger_name: Annotated[
+        str, Field(default="crawlspace", validation_alias="loggerName")
+    ]
+    """The root name of the application's logger."""
 
-    name: str = os.getenv("SAFIR_NAME", "crawlspace")
-    """The application's name, which doubles as the root HTTP endpoint path.
+    log_level: Annotated[
+        str, Field(default="INFO", validation_alias="logLevel")
+    ]
+    """The log level of the application's logger."""
 
-    Set with the ``SAFIR_NAME`` environment variable.
-    """
+    @classmethod
+    def from_file(cls, path: Path) -> Self:
+        """Construct a Configuration object from a configuration file.
 
-    profile: str = os.getenv("SAFIR_PROFILE", "production")
-    """Application run profile: "development" or "production".
+        Parameters
+        ----------
+        path
+            Path to the configuration file in YAML.
 
-    Set with the ``SAFIR_PROFILE`` environment variable.
-    """
-
-    logger_name: str = os.getenv("SAFIR_LOGGER", "crawlspace")
-    """The root name of the application's logger.
-
-    Set with the ``SAFIR_LOGGER`` environment variable.
-    """
-
-    log_level: str = os.getenv("SAFIR_LOG_LEVEL", "INFO")
-    """The log level of the application's logger.
-
-    Set with the ``SAFIR_LOG_LEVEL`` environment variable.
-    """
-
-
-config = Configuration()
-"""Configuration for crawlspace."""
+        Returns
+        -------
+        Config
+            The corresponding `Configuration` object.
+        """
+        with path.open("r") as f:
+            return cls.model_validate(yaml.safe_load(f))

--- a/src/crawlspace/constants.py
+++ b/src/crawlspace/constants.py
@@ -2,6 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+__all__ = ["CONFIG_PATH", "CONFIG_PATH_ENV_VAR", "PATH_REGEX"]
+
+CONFIG_PATH = Path("/etc/crawlspace/config.yaml")
+"""Default path to configuration."""
+
+CONFIG_PATH_ENV_VAR = "CRAWLSPACE_CONFIG_PATH"
+"""Env var to load config path from."""
+
 PATH_REGEX = r"^(/*([^/.]+/+)*[^/.]+(\.[^/.]+)?|/+)?$"
 """Regex matching a valid path.
 

--- a/src/crawlspace/dependencies/config.py
+++ b/src/crawlspace/dependencies/config.py
@@ -1,0 +1,65 @@
+"""Config dependency for FastAPI.
+
+Stolen from Gafaelfawr.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..config import Config
+from ..constants import CONFIG_PATH, CONFIG_PATH_ENV_VAR
+
+__all__ = ["ConfigDependency", "config_dependency"]
+
+
+class ConfigDependency:
+    """Provides the configuration as a dependency.
+
+    We want a production deployment to default to one configuration path, but
+    allow that path to be overridden by the test suite and, if the path
+    changes, to reload the configuration (which allows sharing the same set of
+    global singletons across multiple tests).  Do this by loading the config
+    dynamically when it's first requested and reloading it whenever the
+    configuration path is changed.
+    """
+
+    def __init__(self) -> None:
+        config_path = os.getenv(CONFIG_PATH_ENV_VAR, CONFIG_PATH)
+        self._config_path = Path(config_path)
+        self._config: Config | None = None
+
+    async def __call__(self) -> Config:
+        """Load the configuration if necessary and return it."""
+        return self.config()
+
+    @property
+    def config_path(self) -> Path:
+        """Path to the configuration file."""
+        return self._config_path
+
+    def config(self) -> Config:
+        """Load the configuration if necessary and return it.
+
+        This is equivalent to using the dependency as a callable except that
+        it's not async and can therefore be used from non-async functions.
+        """
+        if not self._config:
+            self._config = Config.from_file(self._config_path)
+        return self._config
+
+    def set_config_path(self, path: Path) -> None:
+        """Change the configuration path and reload the config.
+
+        Parameters
+        ----------
+        path
+            The new configuration path.
+        """
+        self._config_path = path
+        self._config = Config.from_file(path)
+
+
+config_dependency = ConfigDependency()
+"""The dependency that will return the current configuration."""

--- a/src/crawlspace/dependencies/gcs.py
+++ b/src/crawlspace/dependencies/gcs.py
@@ -6,7 +6,7 @@ from contextvars import ContextVar
 
 from google.cloud import storage
 
-from ..config import config
+from ..dependencies.config import config_dependency
 
 _GCS_CLIENT: ContextVar[storage.Client] = ContextVar("_GCS_CLIENT")
 
@@ -21,6 +21,7 @@ class GCSClientDependency:
 
     async def __call__(self) -> storage.client.Client:
         """Return the cached `google.cloud.storage.Client`."""
+        config = config_dependency.config()
         return storage.Client(project=config.gcs_project)
 
 

--- a/src/crawlspace/handlers/internal.py
+++ b/src/crawlspace/handlers/internal.py
@@ -11,7 +11,7 @@ or other information that should not be visible outside the Kubernetes cluster.
 from fastapi import APIRouter
 from safir.metadata import Metadata, get_metadata
 
-from ..config import config
+from ..dependencies.config import config_dependency
 
 __all__ = ["get_index", "internal_router"]
 
@@ -35,6 +35,7 @@ async def get_index() -> Metadata:
 
     By convention, this endpoint returns only the application's metadata.
     """
+    config = config_dependency.config()
     return get_metadata(
         package_name="crawlspace",
         application_name=config.name,

--- a/src/crawlspace/main.py
+++ b/src/crawlspace/main.py
@@ -13,32 +13,35 @@ from fastapi import FastAPI
 from safir.logging import configure_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
-from .config import config
+from .dependencies.config import config_dependency
 from .handlers.external import external_router
 from .handlers.internal import internal_router
 
-__all__ = ["app", "config"]
+__all__ = ["create_app"]
 
 
-configure_logging(
-    profile=config.profile,
-    log_level=config.log_level,
-    name=config.logger_name,
-)
+def create_app() -> FastAPI:
+    """Create the application."""
+    config = config_dependency.config()
+    configure_logging(
+        profile=config.profile,
+        log_level=config.log_level,
+        name=config.logger_name,
+    )
 
-app = FastAPI(
-    title="crawlspace",
-    description=metadata("crawlspace")["Summary"],
-    version=version("crawlspace"),
-    openapi_url=f"{config.url_prefix}/openapi.json",
-    docs_url=f"{config.url_prefix}/docs",
-    redoc_url=f"{config.url_prefix}/redoc",
-)
-"""The main FastAPI application for crawlspace."""
+    app = FastAPI(
+        title="crawlspace",
+        description=metadata("crawlspace")["Summary"],
+        version=version("crawlspace"),
+        openapi_url=f"{config.url_prefix}/openapi.json",
+        docs_url=f"{config.url_prefix}/docs",
+        redoc_url=f"{config.url_prefix}/redoc",
+    )
+    # Attach the routers.
+    app.include_router(internal_router)
+    app.include_router(external_router, prefix=config.url_prefix)
 
-# Attach the routers.
-app.include_router(internal_router)
-app.include_router(external_router, prefix=config.url_prefix)
+    # Add the middleware
+    app.add_middleware(XForwardedMiddleware)
 
-# Add the middleware
-app.add_middleware(XForwardedMiddleware)
+    return app

--- a/src/crawlspace/services/file.py
+++ b/src/crawlspace/services/file.py
@@ -9,7 +9,7 @@ from mimetypes import guess_type
 
 from google.cloud import storage
 
-from ..config import config
+from ..dependencies.config import config_dependency
 from ..exceptions import GCSFileNotFoundError
 
 
@@ -37,6 +37,7 @@ class CrawlspaceFile:
         blob
             Underlying Google Cloud Storage blob.
         """
+        config = config_dependency.config()
         headers = {
             "Cache-Control": f"private, max-age={config.cache_max_age}",
             "Content-Length": str(blob.size),
@@ -94,6 +95,7 @@ class FileService:
         crawlspace.exceptions.GCSFileNotFoundError
             The path was not found in the configured GCS bucket.
         """
+        config = config_dependency.config()
         bucket = self._gcs.bucket(config.gcs_bucket)
         blob = bucket.blob(path)
         if not blob.exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from httpx import ASGITransport, AsyncClient
 from safir.testing.gcs import MockStorageClient, patch_google_storage
 
 from crawlspace import main
+from crawlspace.dependencies.config import config_dependency
+from tests.constants import TEST_DATA_DIR
 
 
 @pytest_asyncio.fixture
@@ -22,8 +24,11 @@ async def app() -> AsyncIterator[FastAPI]:
     Wraps the application in a lifespan manager so that startup and shutdown
     events are sent during test execution.
     """
-    async with LifespanManager(main.app):
-        yield main.app
+    config_path = TEST_DATA_DIR / "config" / "base.yaml"
+    config_dependency.set_config_path(config_path)
+    app = main.create_app()
+    async with LifespanManager(app):
+        yield app
 
 
 @pytest_asyncio.fixture

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,9 @@
+"""Constants for crawlspace tests."""
+
+from pathlib import Path
+
+__all__ = ["TEST_DATA_DIR"]
+
+
+TEST_DATA_DIR = Path(__file__).parent / "data"
+"""Directory that contains test data."""

--- a/tests/data/config/base.yaml
+++ b/tests/data/config/base.yaml
@@ -1,0 +1,2 @@
+gcsProject: someproject
+gcsBucket: somebucket

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -10,7 +10,7 @@ import pytest
 from httpx import AsyncClient
 from safir.testing.gcs import MockStorageClient
 
-from crawlspace.config import config
+from crawlspace.dependencies.config import config_dependency
 
 
 @pytest.mark.asyncio
@@ -21,6 +21,7 @@ async def test_get_files(
     for path in root.iterdir():
         if path.is_dir():
             continue
+        config = config_dependency.config()
         r = await client.get(f"{config.url_prefix}/{path.name}")
         assert r.status_code == 200
         expected_cache = f"private, max-age={config.cache_max_age}"
@@ -61,6 +62,7 @@ async def test_get_root(
 ) -> None:
     index = Path(__file__).parent.parent / "files" / "index.html"
 
+    config = config_dependency.config()
     r = await client.get(config.url_prefix)
     assert r.status_code == 307
     assert r.headers["Location"] == f"https://example.com{config.url_prefix}/"
@@ -78,6 +80,7 @@ async def test_get_root(
 @pytest.mark.asyncio
 async def test_head(client: AsyncClient, mock_gcs: MockStorageClient) -> None:
     root = Path(__file__).parent.parent / "files"
+    config = config_dependency.config()
     for path in root.iterdir():
         if path.is_dir():
             continue
@@ -129,9 +132,11 @@ async def test_head(client: AsyncClient, mock_gcs: MockStorageClient) -> None:
 async def test_errors(
     client: AsyncClient, mock_gcs: MockStorageClient
 ) -> None:
+    config = config_dependency.config()
     r = await client.get(f"{config.url_prefix}/missing")
     assert r.status_code == 404
 
+    config = config_dependency.config()
     for invalid_url in (
         "%2E%2E/%2E%2E/etc/passwd",
         "Norder4/",
@@ -151,6 +156,7 @@ async def test_cache_validation(
 ) -> None:
     index = Path(__file__).parent.parent / "files" / "index.html"
 
+    config = config_dependency.config()
     r = await client.get(f"{config.url_prefix}/")
     assert r.status_code == 200
     etag = r.headers["Etag"]
@@ -196,6 +202,7 @@ async def test_cache_validation(
 async def test_slash_redirect(
     client: AsyncClient, mock_gcs: MockStorageClient
 ) -> None:
+    config = config_dependency.config()
     bad_url = f"{config.url_prefix}//Norder4/Dir0/Npix1794.png"
     good_url = f"{config.url_prefix}/Norder4/Dir0/Npix1794.png"
     r = await client.get(bad_url)

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from crawlspace.config import config
+from crawlspace.dependencies.config import config_dependency
 
 
 @pytest.mark.asyncio
@@ -14,6 +14,7 @@ async def test_get_index(client: AsyncClient) -> None:
     response = await client.get("/")
     assert response.status_code == 200
     data = response.json()
+    config = config_dependency.config()
     assert data["name"] == config.name
     assert isinstance(data["version"], str)
     assert isinstance(data["description"], str)

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,6 @@ uv_sync_flags = --only-group, lint
 [testenv:run]
 description = Run the development server with auto-reload for code changes.
 package = editable
-commands = uvicorn crawlspace.main:app --reload
+set_env =
+    CRAWLSPACE_CONFIG_PATH = tests/data/config/base.yaml
+commands = uvicorn --factory crawlspace.main:create_app --reload

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "google-cloud-storage" },
+    { name = "pydantic" },
     { name = "safir", extra = ["gcs"] },
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
@@ -267,6 +268,7 @@ typing = [
 requires-dist = [
     { name = "fastapi", specifier = "!=0.89.0" },
     { name = "google-cloud-storage" },
+    { name = "pydantic", specifier = ">=2.11" },
     { name = "safir", extras = ["gcs"] },
     { name = "starlette" },
     { name = "uvicorn", extras = ["standard"] },


### PR DESCRIPTION
* Convert config to a Pydantic model
* Read it from a file instead of env vars

This sets the stage to have a dict in the config that maps a dataset name to a GCS project and bucket.

This works (with some [phalanx changes](https://github.com/lsst-sqre/phalanx/pull/4817)):

```
curl --fail-with-body -H "Authorization: Bearer $(op read 'op://Employee/Gafaelfawr Personal Tokens/idfdev')" https://data-dev.lsst.cloud/api/hips/images/2MASS/Color/Moc.fits && \
curl --fail-with-body --head -H "Authorization: Bearer $(op read 'op://Employee/Gafaelfawr Personal Tokens/idfdev')" https://data-dev.lsst.cloud/api/hips/images/2MASS/Color/Moc.fits
```